### PR TITLE
Criar botões de módulo dinamicamente

### DIFF
--- a/modulos-aulas.html
+++ b/modulos-aulas.html
@@ -32,15 +32,18 @@
     <div class="video-name green col-sm-0 col-md-0 col-lg-9"> <!--Também preenchido no script load-module-videos-->
     </div>
 
-    <div class="video-list col-sm-12 col-md-12 col-lg-3"> <!--Idem-->
-    </div>
+    <section class="video-area">
+      <div class="video-list col-sm-12 col-md-12 col-lg-3"> <!--Idem-->
+      </div>
 
-    <div id="scrollToMe-sm-md" class="col-sm-12 col-md-12"></div>
+      <div id="scrollToMe-sm-md" class="col-sm-12 col-md-12"></div>
 
-    <div class="video-name green col-sm-12 col-md-12 col-lg-0"> <!--Também preenchido no script load-module-videos-->
-    </div>
-    <div class="video col-sm-12 col-md-12 col-lg-9"> <!--Ditto (:-->
-    </div>
+      <div class="video-name green col-sm-12 col-md-12 col-lg-0"> <!--Também preenchido no script load-module-videos-->
+      </div>
+
+      <div class="video col-sm-12 col-md-12 col-lg-9"> <!--Ditto (:-->
+      </div>
+    </section>
   </main>
 
   <footer class="col-sm-12 col-md-12 col-lg-12">
@@ -48,8 +51,8 @@
   </footer>
 
   <script src="./scripts/modulos-e-videos/videos-list.js"></script>
-  <script src="./scripts/modulos-e-videos/change-module-buttons.js"></script>
-  <script src="./scripts/modulos-e-videos/checkable-buttons.js"></script>
+  <script src="./scripts/modulos-e-videos/clickable-module-buttons.js"></script>
+  <script src="./scripts/modulos-e-videos/checkable-video-buttons.js"></script>
   <script src="./scripts/modulos-e-videos/load-module-videos.js"></script>
   <!--Quando carregamos o script load-module-videos pela primeira vez ele por padrão está carregando a página com o título "Módulo 1"-->
 </body>

--- a/modulos-aulas.html
+++ b/modulos-aulas.html
@@ -19,16 +19,14 @@
   </header>
 
   <main class="col-sm-12 col-md-12 col-lg-12">
-    <div id="scrollToMe-lg" class="col-sm-0 col-md-0 col-lg-12"></div>
 
     <!--Tanto o campo "modulename" quando o texto são preenchidos no script load-module-videos (linhas 4 e 5)-->
     <h1 class="module-name green" modulename=""></h1>
     <h3 class="darkgrey">O Curso “Back to Work!” está disponível 100% gratuito no Youtube</h3>
 
+    <div id="scrollToMe-lg" class="col-sm-0 col-md-0 col-lg-12"></div>
+
     <div class="change-modules col-sm-12 col-md-12 col-lg-3">
-      <button class="module-button" collectionname="Módulo 1">Módulo </br>1</button>
-      <button class="module-button" collectionname="Módulo 2">Módulo </br>2</button>
-      <button class="module-button" collectionname="Módulo 3">Módulo </br>3</button>
     </div>
 
     <div class="video-name green col-sm-0 col-md-0 col-lg-9"> <!--Também preenchido no script load-module-videos-->
@@ -50,9 +48,9 @@
   </footer>
 
   <script src="./scripts/modulos-e-videos/videos-list.js"></script>
+  <script src="./scripts/modulos-e-videos/change-module-buttons.js"></script>
   <script src="./scripts/modulos-e-videos/checkable-buttons.js"></script>
   <script src="./scripts/modulos-e-videos/load-module-videos.js"></script>
-  <script src="./scripts/modulos-e-videos/change-module-buttons.js"></script>
   <!--Quando carregamos o script load-module-videos pela primeira vez ele por padrão está carregando a página com o título "Módulo 1"-->
 </body>
 </html>

--- a/scripts/modulos-e-videos/change-module-buttons.js
+++ b/scripts/modulos-e-videos/change-module-buttons.js
@@ -1,17 +1,20 @@
-$(".module-button").click(function() {
-  /* Pega o nome do módulo presente no botão clicado e guarda na variável newModuleName */
-  let newModuleName = $(this).text();
-  /* OBS: Esse nome está escrito na mão no html modulos-aulas, nos botões de módulo (+/- linhas 27) */
+function clickableModuleButtons () {
+  $(".module-button").click(function() {
+    /* Pega o nome do módulo presente no botão clicado e guarda na variável newModuleName */
+    let newModuleName = $(this).text();
+    /* OBS: Esse nome está escrito na mão no html modulos-aulas, nos botões de módulo (+/- linhas 27) */
 
-  /* Altera o título da página para o valor que estava no botão clicado */
-  $("h1.module-name").text(newModuleName);
+    /* Altera o título da página para o valor que estava no botão clicado */
+    $("h1.module-name").text(newModuleName);
 
-  /* Apaga as divs com as classes .video, .vide-name e .video-list e chama a função */
-  /* loadModuleVideos para preenchê-las novamente. */
-  $(".video").empty();
-  $(".video-name").empty();
-  $(".video-list").empty();
-  loadModuleVideos(this.getAttribute('collectionname'));
-  /* OBS: Passamos como parâmetro o valor que está no atributo "collectionname" do botão clicado. */
-  /* Este atributo foi criado no html modulos-aula, é um atributo inventado */
-})
+    /* Apaga as divs com as classes .video, .vide-name e .video-list e chama a função */
+    /* loadModuleVideos para preenchê-las novamente. */
+    $(".video").empty();
+    $(".video-name").empty();
+    $(".video-list").empty();
+    $(".change-modules").empty();
+    loadModuleVideos(this.getAttribute('collectionname'));
+    /* OBS: Passamos como parâmetro o valor que está no atributo "collectionname" do botão clicado. */
+    /* Este atributo foi criado no html modulos-aula, é um atributo inventado */
+  });
+}

--- a/scripts/modulos-e-videos/checkable-video-buttons.js
+++ b/scripts/modulos-e-videos/checkable-video-buttons.js
@@ -1,4 +1,4 @@
-function checkableButtons() {
+function checkableVideoButtons() {
   $('.video-button').click(function() {
     /* Pega o valor que está no atributo "modulename" do html e guarda na variável moduleName*/
     let moduleName = $("h1.module-name").attr("modulename");

--- a/scripts/modulos-e-videos/clickable-module-buttons.js
+++ b/scripts/modulos-e-videos/clickable-module-buttons.js
@@ -14,7 +14,5 @@ function clickableModuleButtons () {
     $(".video-list").empty();
     $(".change-modules").empty();
     loadModuleVideos(this.getAttribute('collectionname'));
-    /* OBS: Passamos como parâmetro o valor que está no atributo "collectionname" do botão clicado. */
-    /* Este atributo foi criado no html modulos-aula, é um atributo inventado */
   });
 }

--- a/scripts/modulos-e-videos/load-module-videos.js
+++ b/scripts/modulos-e-videos/load-module-videos.js
@@ -14,6 +14,12 @@ function loadModuleVideos(moduleName){
     /* Coloca o título do primeiro vídeo na tela */
     $(".video-name").text(`${firstVideo.name}`);
 
+    /* Criando dinâmicamente os botões de mudar de módulo */
+    for (let i = 0 ; i < Object.keys(videos).length ; i++) {
+        $(".change-modules").append(`<button class="module-button" collectionname="Módulo ${i+1}">Módulo </br>${i+1}</button>`);
+    }
+    clickableModuleButtons();
+
     /* Coloca a lista com os botões dos vídeos dentro da div com a classe .video-list */
     videos[moduleName].forEach((video) => {
         videolist.append(`<button class="video-button" id="${video.id}">${video.name}</button>`);

--- a/scripts/modulos-e-videos/load-module-videos.js
+++ b/scripts/modulos-e-videos/load-module-videos.js
@@ -24,7 +24,7 @@ function loadModuleVideos(moduleName){
     videos[moduleName].forEach((video) => {
         videolist.append(`<button class="video-button" id="${video.id}">${video.name}</button>`);
     });
-    checkableButtons(); // dá o efeito de clicar e ficar verde aos botões recém gerados acima
+    checkableVideoButtons(); // dá o efeito de clicar e ficar verde aos botões recém gerados acima
 
     /* Deixa verde apenas o botão do módulo correspondente ao título da página em que estamos */
     $('.module-button.checked').removeClass('checked') // remove o verde de algum outro possível botão de módulo que esteja verde

--- a/styles/style.css
+++ b/styles/style.css
@@ -328,7 +328,8 @@ div.btn:active {
     overflow: visible;
     text-align: center;
     margin: 20px 0 15px;
-    height: 20px;
+    min-height: 20px;
+    height: fit-content;
 }
 
 .module-button {

--- a/styles/style.css
+++ b/styles/style.css
@@ -308,6 +308,8 @@ div.btn:active {
 /*****************************//***********************************************/
 /* Página modulos-aulas.html *//***********************************************/
 /*****************************//***********************************************/
+.video-area { width: 100%; }
+
 .video-button {
     margin: 1px auto;
     width: 90%;
@@ -328,7 +330,6 @@ div.btn:active {
     overflow: visible;
     text-align: center;
     margin: 20px 0 15px;
-    min-height: 20px;
     height: fit-content;
 }
 


### PR DESCRIPTION
A página modulos-aulas.html preenche o seu conteúdo de acordo com o módulo escolhido, então faz sentido que os botões para trocar de módulo também sejam criados dinamicamente.
Caso um módulo 4 seja criado, basta colocá-lo no arquivo scripts/modulos-e-videos/videos-list.js seguindo o padrão de objeto:

    videos = {
        "nome do módulo" : [
            { "nome": NOME-DO-VIDEO, "id": ID-DO-VÍDEO-DO-YT},
            { "nome": NOME-DO-OUTRO-VIDEO, "id": ID-DO-OUTRO-VÍDEO-DO-YT}
            ...
        ]
    }
